### PR TITLE
Add tests for config, cli, and main packages

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mrjkey/aggregator/internal/config"
+	"github.com/mrjkey/aggregator/internal/database"
+)
+
+type mockDB struct {
+	users map[string]database.User
+}
+
+func (m *mockDB) GetUser(ctx context.Context, name string) (database.User, error) {
+	user, exists := m.users[name]
+	if !exists {
+		return database.User{}, sql.ErrNoRows
+	}
+	return user, nil
+}
+
+func (m *mockDB) CreateUser(ctx context.Context, arg database.CreateUserParams) (database.User, error) {
+	user := database.User{
+		ID:        arg.ID,
+		CreatedAt: arg.CreatedAt,
+		UpdatedAt: arg.UpdatedAt,
+		Name:      arg.Name,
+	}
+	m.users[arg.Name] = user
+	return user, nil
+}
+
+func TestHandlerLogin(t *testing.T) {
+	mockDB := &mockDB{
+		users: map[string]database.User{
+			"test_user": {
+				ID:        uuid.New(),
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+				Name:      "test_user",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	s := &state{
+		db:  mockDB,
+		cfg: cfg,
+	}
+
+	cmd := command{
+		name: "login",
+		args: []string{"test_user"},
+	}
+
+	err := handlerLogin(s, cmd)
+	if err != nil {
+		t.Fatalf("handlerLogin failed: %v", err)
+	}
+
+	if s.cfg.Current_user_name != "test_user" {
+		t.Errorf("Expected current_user_name to be 'test_user', got '%s'", s.cfg.Current_user_name)
+	}
+}
+
+func TestHandlerRegister(t *testing.T) {
+	mockDB := &mockDB{
+		users: make(map[string]database.User),
+	}
+
+	cfg := &config.Config{}
+	s := &state{
+		db:  mockDB,
+		cfg: cfg,
+	}
+
+	cmd := command{
+		name: "register",
+		args: []string{"new_user"},
+	}
+
+	err := handlerRegister(s, cmd)
+	if err != nil {
+		t.Fatalf("handlerRegister failed: %v", err)
+	}
+
+	if s.cfg.Current_user_name != "new_user" {
+		t.Errorf("Expected current_user_name to be 'new_user', got '%s'", s.cfg.Current_user_name)
+	}
+
+	if _, exists := mockDB.users["new_user"]; !exists {
+		t.Errorf("Expected user 'new_user' to be created in the database")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestRead(t *testing.T) {
+	// Create a temporary config file
+	tempFile, err := os.CreateTemp("", "gatorconfig.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	// Write test data to the temp file
+	testData := `{"db_url": "test_db_url", "current_user_name": "test_user"}`
+	if _, err := tempFile.Write([]byte(testData)); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	tempFile.Close()
+
+	// Override the getFileName function to return the temp file name
+	originalGetFileName := getFileName
+	getFileName = func() string {
+		return tempFile.Name()
+	}
+	defer func() { getFileName = originalGetFileName }()
+
+	// Call the Read function
+	config := Read()
+
+	// Verify the results
+	if config.Db_url != "test_db_url" {
+		t.Errorf("Expected db_url to be 'test_db_url', got '%s'", config.Db_url)
+	}
+	if config.Current_user_name != "test_user" {
+		t.Errorf("Expected current_user_name to be 'test_user', got '%s'", config.Current_user_name)
+	}
+}
+
+func TestSetUser(t *testing.T) {
+	// Create a temporary config file
+	tempFile, err := os.CreateTemp("", "gatorconfig.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	// Write initial test data to the temp file
+	initialData := `{"db_url": "test_db_url", "current_user_name": "initial_user"}`
+	if _, err := tempFile.Write([]byte(initialData)); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	tempFile.Close()
+
+	// Override the getFileName function to return the temp file name
+	originalGetFileName := getFileName
+	getFileName = func() string {
+		return tempFile.Name()
+	}
+	defer func() { getFileName = originalGetFileName }()
+
+	// Read the initial config
+	config := Read()
+
+	// Call the SetUser function
+	newUser := "new_user"
+	if err := config.SetUser(newUser); err != nil {
+		t.Fatalf("Failed to set user: %v", err)
+	}
+
+	// Read the updated config
+	updatedConfig := Read()
+
+	// Verify the results
+	if updatedConfig.Current_user_name != newUser {
+		t.Errorf("Expected current_user_name to be '%s', got '%s'", newUser, updatedConfig.Current_user_name)
+	}
+
+	// Verify the file content
+	fileContent, err := os.ReadFile(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to read temp file: %v", err)
+	}
+	var fileConfig Config
+	if err := json.Unmarshal(fileContent, &fileConfig); err != nil {
+		t.Fatalf("Failed to unmarshal file content: %v", err)
+	}
+	if fileConfig.Current_user_name != newUser {
+		t.Errorf("Expected file current_user_name to be '%s', got '%s'", newUser, fileConfig.Current_user_name)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mrjkey/aggregator/internal/config"
+	"github.com/mrjkey/aggregator/internal/database"
+)
+
+func TestHandlerReset(t *testing.T) {
+	// Mock state
+	s := &state{
+		db:  &mockDB{},
+		cfg: &config.Config{},
+	}
+
+	err := handlerReset(s, command{})
+	if err != nil {
+		t.Errorf("handlerReset() error = %v", err)
+	}
+}
+
+func TestHandlerUsers(t *testing.T) {
+	// Mock state
+	s := &state{
+		db:  &mockDB{},
+		cfg: &config.Config{Current_user_name: "testuser"},
+	}
+
+	err := handlerUsers(s, command{})
+	if err != nil {
+		t.Errorf("handlerUsers() error = %v", err)
+	}
+}
+
+// Mock database implementation
+type mockDB struct{}
+
+func (m *mockDB) RemoveAllUsers(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockDB) RemoveAllFeeds(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockDB) GetUsers(ctx context.Context) ([]database.User, error) {
+	return []database.User{
+		{
+			ID:        uuid.New(),
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Name:      "testuser",
+		},
+	}, nil
+}


### PR DESCRIPTION
Add tests for the `config`, `cli`, and main packages.

* **internal/config/config_test.go**
  - Add tests for `Read` and `SetUser` functions using the `testing` package.
  - Create temporary config files for testing.
  - Verify the results and file content.

* **internal/cli/cli_test.go**
  - Add tests for `handlerLogin` and `handlerRegister` functions using the `testing` package.
  - Mock the database and state for testing.
  - Verify the results and database content.

* **main_test.go**
  - Add tests for `handlerReset` and `handlerUsers` functions using the `testing` package.
  - Mock the database and state for testing.
  - Verify the results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mrjkey/aggregator?shareId=XXXX-XXXX-XXXX-XXXX).